### PR TITLE
Fix KeyError in Moth when Subscriptions built in memory (issue #5)

### DIFF
--- a/sarracenia/config/subscription.py
+++ b/sarracenia/config/subscription.py
@@ -102,8 +102,72 @@ class Subscription(dict):
         self['baseDir'] = options.baseDir
 
 
+def _broker_proto(broker):
+    """Return 'mqtt' or 'amqp' from a broker that may be a Credential or a URL string."""
+    if broker is None:
+        return 'amqp'
+    scheme = ''
+    if hasattr(broker, 'url') and hasattr(broker.url, 'scheme'):
+        scheme = broker.url.scheme or ''
+    else:
+        scheme = str(broker)
+    return 'mqtt' if 'mqtt' in scheme.lower() else 'amqp'
+
+
+def normalize_subscription(subscription):
+    """Convert any pre-3.02 bindings (carrying 'prefix' and 'sub') into the
+    post-3.02 form (carrying a single 'topic' string).
+
+    Idempotent: bindings already in post-3.02 form are left alone.
+
+    Mutates `subscription` in place.
+
+    Previously this conversion only ran inside `Subscriptions.read()` (the
+    JSON-on-disk path). Callers that build `Subscriptions` in memory -- e.g.
+    `sr_insects/static_flow/moth_api_consumer.py` -- left bindings with raw
+    `prefix`+`sub`, and `moth/amqp.py` / `moth/mqtt.py` then raised
+    `KeyError: 'topic'`. See issue #5.
+    """
+    if not isinstance(subscription, dict):
+        return subscription
+    # `bindings_to_remove` is populated by finalize() when diffing against
+    # persisted state. In-memory-constructed subscriptions never get it,
+    # which trips the same KeyError class in moth/amqp.py:432 and
+    # moth/mqtt.py:239. Default to empty.
+    subscription.setdefault('bindings_to_remove', [])
+    proto = _broker_proto(subscription.get('broker'))
+    sep = '/' if proto == 'mqtt' else '.'
+    queue_name = subscription.get('queue', {}).get('name') if isinstance(subscription.get('queue'), dict) else None
+    for b in subscription.get('bindings', []):
+        if 'topic' in b:
+            # Already normalized; strip leftover sub/prefix if present.
+            b.pop('sub', None)
+            b.pop('prefix', None)
+            continue
+        if 'sub' not in b:
+            continue
+        pfx = b.get('prefix', [])
+        sub = b['sub']
+        if not isinstance(pfx, list):
+            pfx = [pfx] if pfx else []
+        if not isinstance(sub, list):
+            sub = [sub]
+        if proto == 'mqtt' and queue_name:
+            b['topic'] = sep.join(['$share', queue_name] + pfx + sub)
+        else:
+            b['topic'] = sep.join(pfx + sub)
+        b.pop('sub', None)
+        b.pop('prefix', None)
+    return subscription
+
+
 class Subscriptions(list):
     # list of subscription
+
+    def __init__(self, iterable=None):
+        super().__init__(iterable if iterable is not None else [])
+        for s in self:
+            normalize_subscription(s)
 
     def read(self,options,fn):
 
@@ -121,33 +185,8 @@ class Subscriptions(list):
                     if ok:
                         s['broker'] = broker
 
-                # old subscriptions (pre 3.02) that have "sub" fields in them need conversion.
-                if 'mqtt' in s['broker'].url.scheme.lower(): 
-                    proto='mqtt'
-                    sep = '/' 
-                else:
-                    proto= 'amqp'
-                    sep = '.'
-
                 # subscription format change, recover for version before 3.02
-
-                for b in s['bindings']:
-                    if 'sub' in b:
-                         pfx=b.get('prefix',[])
-                         sub=b['sub']
-                         if not type(pfx) == list:
-                             pfx=list(pfx)
-                         if not type(sub) == list:
-                             sub=list(sub)
-                         if proto in ['mqtt']:
-                             b['topic'] =  sep.join( [ '$share', s['queue']['name'] ] + pfx + sub )
-                         else:
-                             b['topic'] =  sep.join(pfx+sub)
-
-                    if 'sub' in b:
-                        del b['sub']
-                    if 'prefix' in b:
-                        del b['prefix']
+                normalize_subscription(s)
 
                 if 'queue' in s:
                     if not 'tlsRigour' in s['queue']:
@@ -188,6 +227,8 @@ class Subscriptions(list):
             logger.debug('Exception details: ', exc_info=True)
 
     def add(self, new_subscription):
+
+        normalize_subscription(new_subscription)
 
         found=False
         for s in self:

--- a/tests/sarracenia/subscription_test.py
+++ b/tests/sarracenia/subscription_test.py
@@ -1,0 +1,162 @@
+import pytest
+from tests.conftest import *
+
+from sarracenia.config.subscription import Subscriptions, normalize_subscription
+
+
+class _FakeUrl:
+    def __init__(self, scheme):
+        self.scheme = scheme
+
+
+class _FakeBroker:
+    def __init__(self, scheme):
+        self.url = _FakeUrl(scheme)
+
+    def __str__(self):
+        return f"{self.url.scheme}://fake"
+
+
+def _amqp_sub():
+    return {
+        'broker': _FakeBroker('amqps'),
+        'bindings': [{'exchange': 'xpublic', 'prefix': ['v02', 'post'], 'sub': ['#']}],
+        'queue': {'name': 'q_anonymous_test_host_abc'},
+    }
+
+
+def _mqtt_sub():
+    return {
+        'broker': _FakeBroker('mqtts'),
+        'bindings': [{'prefix': ['v02', 'post'], 'sub': ['#']}],
+        'queue': {'name': 'q_test'},
+    }
+
+
+def test_normalize_subscription_amqp_joins_with_dot():
+    s = _amqp_sub()
+    normalize_subscription(s)
+    b = s['bindings'][0]
+    assert b['topic'] == 'v02.post.#'
+    assert b['exchange'] == 'xpublic'
+    assert 'sub' not in b and 'prefix' not in b
+
+
+def test_normalize_subscription_mqtt_joins_with_slash_and_shares():
+    s = _mqtt_sub()
+    normalize_subscription(s)
+    b = s['bindings'][0]
+    assert b['topic'] == '$share/q_test/v02/post/#'
+    assert 'sub' not in b and 'prefix' not in b
+
+
+def test_normalize_subscription_is_idempotent():
+    s = _amqp_sub()
+    normalize_subscription(s)
+    before = dict(s['bindings'][0])
+    normalize_subscription(s)
+    assert s['bindings'][0] == before
+
+
+def test_normalize_subscription_leaves_existing_topic_alone():
+    s = {
+        'broker': _FakeBroker('amqp'),
+        'bindings': [{'exchange': 'xpublic', 'topic': 'already.set.#'}],
+        'queue': {'name': 'q'},
+    }
+    normalize_subscription(s)
+    assert s['bindings'][0]['topic'] == 'already.set.#'
+
+
+def test_normalize_subscription_strips_stale_sub_when_topic_present():
+    # A binding that somehow has both: topic wins, leftovers cleared.
+    s = {
+        'broker': _FakeBroker('amqp'),
+        'bindings': [{'exchange': 'xpublic', 'topic': 'already.set.#',
+                      'prefix': ['v02'], 'sub': ['#']}],
+        'queue': {'name': 'q'},
+    }
+    normalize_subscription(s)
+    b = s['bindings'][0]
+    assert b['topic'] == 'already.set.#'
+    assert 'sub' not in b and 'prefix' not in b
+
+
+def test_normalize_subscription_no_queue():
+    # Publisher-side subscription dicts may not carry a queue. Should not crash.
+    s = {
+        'broker': _FakeBroker('amqp'),
+        'bindings': [{'exchange': 'xpublic', 'prefix': ['v02', 'post'], 'sub': ['#']}],
+    }
+    normalize_subscription(s)
+    assert s['bindings'][0]['topic'] == 'v02.post.#'
+
+
+def test_normalize_subscription_scalar_prefix_and_sub():
+    s = {
+        'broker': _FakeBroker('amqp'),
+        'bindings': [{'exchange': 'xpublic', 'prefix': 'v02', 'sub': '#'}],
+        'queue': {'name': 'q'},
+    }
+    normalize_subscription(s)
+    assert s['bindings'][0]['topic'] == 'v02.#'
+
+
+def test_subscriptions_init_normalizes_amqp():
+    # This is the regression case for issue #5: in-memory construction via
+    # Subscriptions([...]) previously left bindings as prefix+sub, and
+    # moth/amqp.py raised KeyError: 'topic' on use.
+    subs = Subscriptions([_amqp_sub()])
+    assert subs[0]['bindings'][0]['topic'] == 'v02.post.#'
+    assert 'sub' not in subs[0]['bindings'][0]
+
+
+def test_subscriptions_init_normalizes_mqtt():
+    subs = Subscriptions([_mqtt_sub()])
+    assert subs[0]['bindings'][0]['topic'] == '$share/q_test/v02/post/#'
+
+
+def test_subscriptions_init_empty():
+    subs = Subscriptions()
+    assert len(subs) == 0
+    subs2 = Subscriptions(None)
+    assert len(subs2) == 0
+    subs3 = Subscriptions([])
+    assert len(subs3) == 0
+
+
+def test_subscriptions_add_normalizes():
+    subs = Subscriptions()
+    subs.add(_amqp_sub())
+    assert subs[0]['bindings'][0]['topic'] == 'v02.post.#'
+
+
+def test_normalize_subscription_defaults_bindings_to_remove():
+    # moth/amqp.py:432 iterates subscription['bindings_to_remove'] directly.
+    # In-memory subs never carry that key, which produced a second KeyError
+    # after the 'topic' fix. Normalize must default it to [].
+    s = _amqp_sub()
+    assert 'bindings_to_remove' not in s
+    normalize_subscription(s)
+    assert s['bindings_to_remove'] == []
+
+
+def test_subscriptions_init_defaults_bindings_to_remove():
+    subs = Subscriptions([_amqp_sub()])
+    assert subs[0]['bindings_to_remove'] == []
+
+
+def test_subscriptions_add_merges_new_binding():
+    subs = Subscriptions([_amqp_sub()])
+    # Second subscription, same broker+queue, different binding in pre-3.02 shape.
+    second = {
+        'broker': _FakeBroker('amqps'),
+        'bindings': [{'exchange': 'xpublic', 'prefix': ['v03'], 'sub': ['post.#']}],
+        'queue': {'name': 'q_anonymous_test_host_abc'},
+    }
+    subs.add(second)
+    # Must have merged into the first entry as a second binding, with topic computed.
+    assert len(subs) == 1
+    topics = [b['topic'] for b in subs[0]['bindings']]
+    assert 'v02.post.#' in topics
+    assert 'v03.post.#' in topics


### PR DESCRIPTION
Closes #5.

## Summary

`Subscriptions.read()` (JSON-on-disk path) converts pre-3.02 `{prefix, sub}` bindings to `{topic}` bindings. `Subscriptions([...])` built in memory did not, so `moth/amqp.py:423` and `moth/mqtt.py:233` raised `KeyError: 'topic'` when consumers like `sr_insects/static_flow/moth_api_consumer.py` ran. A second KeyError of the same class (`'bindings_to_remove'`) fired once the topic issue was patched -- `moth/amqp.py:432` iterates that key directly but in-memory subs never populate it.

The retry loop in `getSetup()` catches the exception, logs `failed connection to ...: 'topic'`, and spins forever. In GHA this eats the full 20-min CI budget and shows up as a mysterious \"timeout failure.\" This is what is masking CI signal on other PRs (e.g. PR #4).

## Fix

In `sarracenia/config/subscription.py`:

- Extract the `prefix+sub -> topic` conversion into `normalize_subscription(s)` (module-level, idempotent, mutates in place).
- `Subscriptions.__init__` normalizes each passed-in subscription on construction.
- `Subscriptions.add()` normalizes `new_subscription` before merging.
- `read()` now delegates to the same helper (single source of truth).
- `normalize_subscription` also sets `bindings_to_remove = []` by default.

No API changes. Callers that already pass the post-3.02 shape with `topic` are unaffected (normalization is idempotent).

## Tests

Adds `tests/sarracenia/subscription_test.py` with **14 unit tests** covering:

- AMQP `.` join, MQTT `/` join with `$share/<queue>` prefix for shared subscriptions
- Idempotence, existing-topic pass-through, stale sub/prefix stripping
- Publisher-side subs without `queue`, scalar (non-list) prefix/sub
- `Subscriptions([...])`, `Subscriptions()`, `Subscriptions(None)`, `Subscriptions([])`
- `Subscriptions.add()` normalization + merging a second pre-3.02 binding
- `bindings_to_remove` defaulted by both `normalize_subscription` and `__init__`

All 14 pass. 28/28 pass across `config_test.py + credentials_test.py + subscription_test.py`. 15/15 pass across `sarracenia/moth/` (excluding `amq1_test.py`, which needs `proton`, unrelated).

## End-to-end verification

Before the fix, against `development` on `edcm-dirt22-2`:

```
$ cd ~/src/sr_insects/static_flow && python3 moth_api_consumer.py
[INFO]  queue declared q_anonymous_...
[ERROR] getSetup failed connection to amqps://anonymous@hpfx.collab.science.gc.ca: 'topic'
[CRITICAL] too soon to connect again, will try in: 1.10 seconds
[ERROR] getSetup failed connection to amqps://anonymous@hpfx.collab.science.gc.ca: 'topic'
... (loops forever) ...
```

After this fix:

```
$ cd ~/src/sr_insects/static_flow && python3 moth_api_consumer.py
[INFO] queue declared q_anonymous_...
[INFO] binding q_anonymous_... with v02.post.# to xpublic (as: amqps://anonymous@hpfx.collab.science.gc.ca)
 got 5 messages
```

Full `flow_maint_test.sh`:

```
test  1 success: queues baseline
test  2 success: moth_api_consumer.py example should consume 5 messages
test  3 success: flow_api_consumer.py should consume 5 messages, found 5
test  4 success: post-cleanup queue count
test  5 success: erase test
Overall 5 of 5 passed
EXIT=0
```

## Test plan

- [x] `pytest tests/sarracenia/subscription_test.py` -- 14 passed
- [x] `pytest tests/sarracenia/config_test.py` -- 16 passed
- [x] `pytest tests/sarracenia/moth/ --ignore=.../amq1_test.py` -- 15 passed
- [x] `moth_api_consumer.py` round-trips cleanly against hpfx
- [x] `flow_maint_test.sh` all 5 tests pass
- [ ] Fork CI green