### PR TITLE
fix: cancel SIGALRM before ftp cleanup on failed connect

### DIFF
--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -265,13 +265,17 @@ class Ftp(Transfer):
             self.ftp = ftp
 
         except Exception:
+            # Cancel the connect-timeout alarm before any cleanup so SIGALRM
+            # cannot interrupt ftp.close() and mask the original failure.
+            alarm_cancel()
             logger.error("Unable to connect to %s (user:%s)", self.host, self.user)
             logger.debug('Exception details: ', exc_info=True)
             if ftp is not None:
                 try:
                     ftp.close()
-                except Exception:
-                    pass
+                except Exception as cleanup_err:
+                    logger.debug("ftp.close failed during cleanup: %s", cleanup_err)
+            return self.connected
 
         alarm_cancel()
         return self.connected

--- a/tests/sarracenia/transfer/ftp_test.py
+++ b/tests/sarracenia/transfer/ftp_test.py
@@ -144,3 +144,52 @@ def test_connect_success_does_not_close():
     assert transfer.connected is True
     assert transfer.ftp is mock_ftp
     mock_ftp.close.assert_not_called()
+
+
+def test_connect_cancels_alarm_before_close_on_failure():
+    # Lock in the SIGALRM-safe ordering: on failure, alarm_cancel must run
+    # before ftp.close() so a pending SIGALRM cannot interrupt cleanup.
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.return_value = None
+    mock_ftp.login.side_effect = ftplib.error_perm("530 Login incorrect")
+
+    call_order = []
+
+    def record_cancel():
+        call_order.append("alarm_cancel")
+
+    def record_close():
+        call_order.append("ftp.close")
+
+    mock_ftp.close.side_effect = record_close
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel", side_effect=record_cancel):
+                result = transfer.connect()
+
+    assert result is False
+    assert call_order == ["alarm_cancel", "ftp.close"], \
+        "alarm_cancel must run before ftp.close on the failure path"
+
+
+def test_connect_swallows_close_error_during_cleanup():
+    # If ftp.close itself raises during cleanup, connect must still return
+    # cleanly (False) rather than propagating the cleanup error.
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.return_value = None
+    mock_ftp.login.side_effect = ftplib.error_perm("530 Login incorrect")
+    mock_ftp.close.side_effect = OSError("close failed")
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                result = transfer.connect()
+
+    assert result is False
+    assert transfer.connected is False
+    mock_ftp.close.assert_called_once()


### PR DESCRIPTION
##### Summary

Follow-up to PR #15. The connect-timeout alarm set at the top of `Ftp.connect()` stayed armed across the except branch, so `ftp.close()` ran while SIGALRM was still pending. A fired alarm could interrupt cleanup and mask the original failure.

This moves `alarm_cancel()` to be the first statement in the except branch, before `ftp.close()`. The success path keeps the trailing `alarm_cancel()` as before.

Also logs `ftp.close()` cleanup failures at debug instead of swallowing them silently, so cascading socket exhaustion stays diagnosable.

##### Test plan

- `python3 -m pytest tests/sarracenia/transfer/ftp_test.py -v` - 7 passed (2 new)
- `pycodestyle --max-line-length=119 tests/sarracenia/transfer/ftp_test.py` - clean
- `git diff --check` - clean

##### New tests

- `test_connect_cancels_alarm_before_close_on_failure` - records call order via `side_effect` to lock in `alarm_cancel` before `ftp.close`.
- `test_connect_swallows_close_error_during_cleanup` - verifies a raising `close()` still returns `False` cleanly.

##### Notes

Stacked on `fix/ftp-connect-fd-leak-refresh` (PR #15). Merge that first, then this rebases onto development.