### PR TITLE
style: use 'is None' instead of '== None' in Ftp.connect

### DIFF
--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -218,7 +218,7 @@ class Ftp(Transfer):
         try:
             expire = -999
             if self.o.timeout: expire = self.o.timeout
-            if self.port == '' or self.port == None:
+            if self.port == '' or self.port is None:
                 if self.implicit_ftps:
                     self.port = 990
                 else:


### PR DESCRIPTION
##### Summary

One-line PEP 8 cleanup. `self.port == None` should be `self.port is None` (E711). The same line was already touched by PR #15 for a trailing-whitespace cleanup, so this finishes what started there.

##### Test plan

- `python3 -m pytest tests/sarracenia/transfer/ftp_test.py -q` - 7 passed
- `pycodestyle --max-line-length=119 sarracenia/transfer/ftp.py` - E711 on this line is gone (other pre-existing violations remain, out of scope)

##### Notes

Stacked on `fix/ftp-connect-sigalrm-cleanup` (PR #16).