### PR TITLE
fix: assign self.ftp before setting self.connected in Ftp.connect

### DIFF
--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -260,9 +260,12 @@ class Ftp(Transfer):
                 logger.warning("Unable to ftp.pwd")
                 logger.debug('Exception details: ', exc_info=True)
 
+            # Publish the ftp handle before flipping the connected flag so
+            # any reader that sees connected=True is guaranteed to see a
+            # non-None self.ftp.
             self.pwd = self.originalDir
-            self.connected = True
             self.ftp = ftp
+            self.connected = True
 
         except Exception:
             # Cancel the connect-timeout alarm before any cleanup so SIGALRM


### PR DESCRIPTION
##### Summary

If another worker checks `self.connected` between the two assignments and dereferences `self.ftp`, it can see `connected=True` while `self.ftp` is still `None` (or the previous handle). Swap the order so the handle is published before the flag flips.

Single-process callers won't observe the race, but Sarracenia flow components can spawn worker processes/threads that share Ftp state in some configurations. `check_is_connected()` reads both fields and would be the most likely victim.

##### Diff

```python
# before
self.pwd = self.originalDir
self.connected = True
self.ftp = ftp

# after
self.pwd = self.originalDir
self.ftp = ftp
self.connected = True
```

##### Test plan

- `python3 -m pytest tests/sarracenia/transfer/ftp_test.py -q` - 7 passed
- The existing `test_connect_success_does_not_close` already asserts both `transfer.connected is True` and `transfer.ftp is mock_ftp`, so the swap doesn't break the happy path.

##### Notes

Stacked on `fix/ftp-connect-sigalrm-cleanup` (PR #16). Pre-existing issue, not introduced by PR #15.