### PR TITLE
fix: close orphan FTP socket on KeyboardInterrupt and SystemExit

### DIFF
--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -216,71 +216,76 @@ class Ftp(Transfer):
 
         ftp = None
         try:
-            expire = -999
-            if self.o.timeout: expire = self.o.timeout
-            if self.port == '' or self.port == None:
-                if self.implicit_ftps:
-                    self.port = 990
-                else:
-                    self.port = 21
-
-            # plain FTP with no encryption (usually port 21)
-            if not self.tls:
-                ftp = ftplib.FTP()
-                ftp.encoding = 'utf-8'
-                ftp.connect(self.host, self.port, timeout=expire)
-                ftp.login(self.user, self.password)
-            # implicit FTPS (usually port 990)
-            elif self.tls and self.implicit_ftps:
-                ftp = IMPLICIT_FTP_TLS()
-                ftp.encoding = self.o.ftpFilenameEncoding
-                ftp.connect(host=self.host, port=self.port, timeout=expire)
-                ftp.login(user=self.user, passwd=self.password)
-                if self.prot_p:
-                    ftp.prot_p()
-            # explicit FTPS (port 21)
-            else:
-                # ftplib supports FTPS with TLS
-                ftp = ftplib.FTP_TLS(self.host,
-                                     self.user,
-                                     self.password,
-                                     timeout=expire)
-                ftp.encoding = self.o.ftpFilenameEncoding
-                if self.prot_p: ftp.prot_p()
-                # needed only if prot_p then set back to prot_c
-                #else          : ftp.prot_c()
-
-            ftp.set_pasv(self.passive)
-
-            self.originalDir = '.'
-
             try:
-                self.originalDir = ftp.pwd()
+                expire = -999
+                if self.o.timeout: expire = self.o.timeout
+                if self.port == '' or self.port == None:
+                    if self.implicit_ftps:
+                        self.port = 990
+                    else:
+                        self.port = 21
+
+                # plain FTP with no encryption (usually port 21)
+                if not self.tls:
+                    ftp = ftplib.FTP()
+                    ftp.encoding = 'utf-8'
+                    ftp.connect(self.host, self.port, timeout=expire)
+                    ftp.login(self.user, self.password)
+                # implicit FTPS (usually port 990)
+                elif self.tls and self.implicit_ftps:
+                    ftp = IMPLICIT_FTP_TLS()
+                    ftp.encoding = self.o.ftpFilenameEncoding
+                    ftp.connect(host=self.host, port=self.port, timeout=expire)
+                    ftp.login(user=self.user, passwd=self.password)
+                    if self.prot_p:
+                        ftp.prot_p()
+                # explicit FTPS (port 21)
+                else:
+                    # ftplib supports FTPS with TLS
+                    ftp = ftplib.FTP_TLS(self.host,
+                                         self.user,
+                                         self.password,
+                                         timeout=expire)
+                    ftp.encoding = self.o.ftpFilenameEncoding
+                    if self.prot_p: ftp.prot_p()
+                    # needed only if prot_p then set back to prot_c
+                    #else          : ftp.prot_c()
+
+                ftp.set_pasv(self.passive)
+
+                self.originalDir = '.'
+
+                try:
+                    self.originalDir = ftp.pwd()
+                except Exception:
+                    logger.warning("Unable to ftp.pwd")
+                    logger.debug('Exception details: ', exc_info=True)
+
+                # Publish the ftp handle before flipping the connected flag so
+                # any reader that sees connected=True is guaranteed to see a
+                # non-None self.ftp.
+                self.pwd = self.originalDir
+                self.ftp = ftp
+                self.connected = True
+                # Ownership transferred to self.ftp; the finally below must
+                # not close it.
+                ftp = None
+
             except Exception:
-                logger.warning("Unable to ftp.pwd")
+                logger.error("Unable to connect to %s (user:%s)", self.host, self.user)
                 logger.debug('Exception details: ', exc_info=True)
-
-            # Publish the ftp handle before flipping the connected flag so
-            # any reader that sees connected=True is guaranteed to see a
-            # non-None self.ftp.
-            self.pwd = self.originalDir
-            self.ftp = ftp
-            self.connected = True
-
-        except Exception:
-            # Cancel the connect-timeout alarm before any cleanup so SIGALRM
-            # cannot interrupt ftp.close() and mask the original failure.
+        finally:
+            # alarm_cancel first so a pending SIGALRM cannot interrupt the
+            # close below. This finally also runs on KeyboardInterrupt and
+            # SystemExit, so an orphan socket created before the assignment
+            # to self.ftp will still be closed.
             alarm_cancel()
-            logger.error("Unable to connect to %s (user:%s)", self.host, self.user)
-            logger.debug('Exception details: ', exc_info=True)
             if ftp is not None:
                 try:
                     ftp.close()
                 except Exception as cleanup_err:
                     logger.debug("ftp.close failed during cleanup: %s", cleanup_err)
-            return self.connected
 
-        alarm_cancel()
         return self.connected
 
     # credentials...

--- a/tests/sarracenia/transfer/ftp_test.py
+++ b/tests/sarracenia/transfer/ftp_test.py
@@ -126,6 +126,40 @@ def test_connect_keyboard_interrupt_propagates():
                     transfer.connect()
 
 
+def test_connect_closes_ftp_on_keyboard_interrupt():
+    # KeyboardInterrupt during the connect call must NOT leak the open
+    # socket. The finally block closes ftp before the interrupt propagates.
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.side_effect = KeyboardInterrupt
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                with pytest.raises(KeyboardInterrupt):
+                    transfer.connect()
+
+    mock_ftp.close.assert_called_once()
+
+
+def test_connect_closes_ftp_on_system_exit():
+    # Same protection as KeyboardInterrupt: SystemExit also escapes
+    # except Exception, so the finally block must still close ftp.
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.side_effect = SystemExit
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                with pytest.raises(SystemExit):
+                    transfer.connect()
+
+    mock_ftp.close.assert_called_once()
+
+
 def test_connect_success_does_not_close():
     transfer = make_ftp_transfer()
 


### PR DESCRIPTION
##### Summary

Closes the loop on the follow-up PR #15's body promised. PR #15's `except Exception` cleanup catches normal connect failures but not `BaseException` subclasses. If `KeyboardInterrupt` or `SystemExit` fires after `ftp = ftplib.FTP()` but before `self.ftp = ftp`, the local `ftp` variable holds an open socket that nothing ever closes, and the connect-timeout alarm stays armed.

This is the `try/finally` restructure I said in PR #15 would be needed.

##### What changed

Wrapped the inner connect logic in an outer `try/finally`. On the success path, `ftp` is set to `None` after `self.ftp = ftp` so the finally won't close the live handle. On any exit (including `BaseException`), the finally:

1. Calls `alarm_cancel()` first (preserves the SIGALRM ordering locked in by PR #16).
2. Closes the orphan socket if `ftp is not None`.

The diff looks big because the inner block got re-indented one level. Logic delta is small.

##### New tests

- `test_connect_closes_ftp_on_keyboard_interrupt` - verifies `ftp.close` is called even when `KeyboardInterrupt` propagates.
- `test_connect_closes_ftp_on_system_exit` - covers the `SystemExit` path.

##### Test plan

- `python3 -m pytest tests/sarracenia/transfer/ftp_test.py -v` - 9 passed (2 new)
- `pycodestyle --max-line-length=119 tests/sarracenia/transfer/ftp_test.py` - clean
- `git diff --check` - clean

##### Notes

Stacked on `fix/ftp-state-ordering` (PR #19). With this in, all known issues from the consensus adversarial review of PR #15 are addressed.