### PR TITLE
ci: also tag container image with version stripped of v prefix

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -66,6 +66,9 @@ jobs:
             type=raw,value=development,enable=${{ github.ref == 'refs/heads/development' }}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=ref,event=tag
+            # also tag with the version stripped of the v prefix (v3.03.00 -> 3.03.00)
+            # so downstream consumers can pin to the bare version number.
+            type=match,pattern=v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v7


### PR DESCRIPTION
##### Summary

Follow-up to upstream #1676. The comment in `ghcr.yml:63` said *"images built from tags will get tagged 'stable' and a tag matching the version (without the v prefix)"*, but the actual config only produces `:v3.03.00` via `type=ref,event=tag` - the `v` prefix is preserved. Downstream consumers referencing the unprefixed alias (e.g. `ghcr.io/metpx/sarracenia:3.03.00`) will break on the next stable release.

Add a `type=match` pattern that strips the leading `v` from semver-shaped tags. After this change, a push of `v3.03.00` produces image tags `:latest`, `:stable`, `:v3.03.00`, `:3.03.00`.

##### Diff

```yaml
          tags: |
            type=raw,value=latest
            type=raw,value=development,enable=${{ github.ref == 'refs/heads/development' }}
            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/') }}
            type=ref,event=tag
+           # also tag with the version stripped of the v prefix (v3.03.00 -> 3.03.00)
+           # so downstream consumers can pin to the bare version number.
+           type=match,pattern=v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
```

##### Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ghcr.yml'))"` - YAML parses
- `git diff --check` - clean
- The existing trigger filter already excludes `v2.*` tags, so this only applies to v3+ releases.

##### Notes

Fork-first per workflow. After this lands on the fork, it'll get promoted upstream against `MetPX/sarracenia:development`.