### PR TITLE
docker: pin Dockerfile_base to ubuntu:24.04

### DIFF
--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,4 +1,8 @@
-FROM ubuntu:latest
+# Pinned to 24.04 because this image relies on python3-paho-mqtt >= 1.5.1
+# being available from apt. 24.04 ships 1.6.1; older Ubuntu LTS releases
+# did not, which is why the previous Dockerfile installed paho-mqtt via pip.
+# When a newer Ubuntu LTS is ready, audit the apt package versions and bump.
+FROM ubuntu:24.04
 
 LABEL maintainer="ssc.sscdatarouting-spcroutagededonnees.spc@ssc-spc.gc.ca"
 


### PR DESCRIPTION
##### Summary

Follow-up to upstream #1676. That PR removed the `pip install --break-system-packages paho-mqtt` workaround because Ubuntu 24.04 ships `python3-paho-mqtt` 1.6.1, meeting Sarracenia's 1.5.1 minimum. The Dockerfile still says `FROM ubuntu:latest`, so the version assumption holds only as long as `:latest` resolves to 24.04. When 26.04 LTS releases and `:latest` rolls forward, the assumption could quietly break if Ubuntu changes the paho-mqtt package version or naming.

Pin to `ubuntu:24.04` and document why. When a newer LTS is ready, this gets re-pinned after auditing the apt package versions.

##### Diff

```dockerfile
+# Pinned to 24.04 because this image relies on python3-paho-mqtt >= 1.5.1
+# being available from apt. 24.04 ships 1.6.1; older Ubuntu LTS releases
+# did not, which is why the previous Dockerfile installed paho-mqtt via pip.
+# When a newer Ubuntu LTS is ready, audit the apt package versions and bump.
+FROM ubuntu:24.04
-FROM ubuntu:latest
```

##### Test plan

- `docker build -f Dockerfile_base -t sarracenia-base-test .` succeeds locally against the pinned base
- `apt-cache policy python3-paho-mqtt` inside the resulting image confirms version 1.6.1
- `git diff --check` - clean

##### Notes

Fork-first per workflow. After this lands on the fork, it'll get promoted upstream against `MetPX/sarracenia:development`.