### PR TITLE
test: add mock-paramiko regression net for sarracenia.transfer.sftp (paramiko-upgrade Stage 0)

### DIFF
--- a/tests/sarracenia/transfer/sftp_test.py
+++ b/tests/sarracenia/transfer/sftp_test.py
@@ -1,0 +1,373 @@
+"""
+Mock-paramiko regression tests for sarracenia.transfer.sftp.
+
+These tests are the regression net that lets the paramiko-pin work proceed
+safely. They exercise the surface of Sftp that interacts with paramiko APIs
+without touching the network:
+
+    * SSHClient.connect() kwarg propagation in both auth branches
+    * SFTPClient.file() get/put happy paths via the read_writelocal /
+      readlocal_write loop
+    * SFTPClient.listdir_attr() parsing through Sftp.ls / line_callback,
+      including the attr.__str__() token layout that line_callback parses
+      with ' '.join(opart2[8:]) at sftp.py:444
+    * Identity check `type(line) is paramiko.SFTPAttributes` used by
+      flowcb/poll/__init__.py:358
+    * Failure paths (credentials False, ssh.connect raises) returning False
+    * Scheme registration
+
+Run under each paramiko leg of the matrix (2.9.x, 3.x, 4.x) to confirm the
+API surface and the textual SFTPAttributes layout are stable.
+"""
+import io
+import logging
+import stat as stat_mod
+
+from unittest.mock import MagicMock, patch
+
+import paramiko
+import pytest
+
+import sarracenia
+import sarracenia.config
+import sarracenia.transfer
+import sarracenia.transfer.sftp
+
+from tests.conftest import *  # noqa: F401,F403
+
+logger = logging.getLogger('sarracenia.transfer.sftp')
+logger.setLevel('DEBUG')
+
+
+def _make_sftp():
+    """Build a real Sftp instance without opening a socket.
+
+    Sftp.__init__ only reads ~/.ssh/config and registers options; no I/O
+    happens until connect() is called.
+    """
+    options = sarracenia.config.default_config()
+    xfer = sarracenia.transfer.sftp.Sftp('sftp', options)
+    xfer.host = 'testhost'
+    xfer.port = 22
+    xfer.user = 'tester'
+    xfer.password = None
+    xfer.ssh_keyfile = None
+    xfer.sendTo = 'sftp://tester@testhost/'
+    xfer.o.sendTo = xfer.sendTo
+    return xfer
+
+
+def _fake_attr(filename, size=1234, mtime=1700000000, mode=stat_mod.S_IFREG | 0o644,
+               uid=1000, gid=1000):
+    """Build a real paramiko.SFTPAttributes with populated fields.
+
+    Uses the live paramiko module so that attr.__str__() exercises whichever
+    paramiko version is installed. That __str__ output is what line_callback
+    parses; this helper is the canary for format drift across paramiko
+    versions.
+    """
+    a = paramiko.SFTPAttributes()
+    a.st_size = size
+    a.st_mtime = mtime
+    a.st_mode = mode
+    a.st_uid = uid
+    a.st_gid = gid
+    a.filename = filename
+    a.longname = filename
+    return a
+
+
+# ----- factory / scheme registration -----
+
+
+def test_registered_as_includes_sftp_scp_ssh_fish():
+    schemes = sarracenia.transfer.sftp.Sftp.registered_as()
+    assert 'sftp' in schemes
+    assert 'scp' in schemes
+    assert 'ssh' in schemes
+    assert 'fish' in schemes
+
+
+def test_factory_returns_sftp_instance():
+    options = sarracenia.config.default_config()
+    xfer = sarracenia.transfer.Transfer.factory('sftp', options)
+    assert isinstance(xfer, sarracenia.transfer.sftp.Sftp)
+
+
+# ----- connect: kwarg propagation -----
+
+
+def _make_fake_client(getcwd='/home/tester'):
+    fake_client = MagicMock()
+    fake_sftp = MagicMock()
+    fake_sftp.getcwd.return_value = getcwd
+    fake_channel = MagicMock()
+    fake_sftp.get_channel.return_value = fake_channel
+    fake_client.open_sftp.return_value = fake_sftp
+    return fake_client, fake_sftp
+
+
+def test_connect_key_auth_kwargs():
+    """Key-based auth branch (no password): verify the exact kwargs paramiko receives."""
+    xfer = _make_sftp()
+    xfer.password = None
+    xfer.ssh_keyfile = '/tmp/fake.key'
+
+    fake_client, _ = _make_fake_client()
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        ok = xfer.connect()
+
+    assert ok is True
+    args, kwargs = fake_client.connect.call_args
+    # positional: (host, port, user, password)
+    assert args[0] == 'testhost'
+    assert args[1] == 22
+    assert args[2] == 'tester'
+    assert args[3] is None  # password
+    assert kwargs.get('pkey') is None
+    assert kwargs.get('key_filename') == '/tmp/fake.key'
+    assert 'timeout' in kwargs
+
+
+def test_connect_password_auth_kwargs():
+    """Password auth branch: allow_agent=False, look_for_keys=False are pinned."""
+    xfer = _make_sftp()
+    xfer.password = 'secret'
+
+    fake_client, _ = _make_fake_client()
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        ok = xfer.connect()
+
+    assert ok is True
+    args, kwargs = fake_client.connect.call_args
+    # password branch passes the unquoted password as the 4th positional
+    assert args[3] == 'secret'
+    assert kwargs.get('allow_agent') is False
+    assert kwargs.get('look_for_keys') is False
+
+
+def test_connect_sets_missing_host_key_policy_to_autoadd():
+    xfer = _make_sftp()
+    fake_client, _ = _make_fake_client()
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        xfer.connect()
+    assert fake_client.set_missing_host_key_policy.called
+    policy_arg = fake_client.set_missing_host_key_policy.call_args[0][0]
+    assert isinstance(policy_arg, paramiko.AutoAddPolicy)
+
+
+def test_connect_returns_false_when_credentials_fail():
+    xfer = _make_sftp()
+    with patch.object(xfer, 'credentials', return_value=False):
+        ok = xfer.connect()
+    assert ok is False
+    assert xfer.connected is False
+
+
+def test_connect_returns_false_on_ssh_connect_exception():
+    xfer = _make_sftp()
+    fake_client = MagicMock()
+    fake_client.connect.side_effect = OSError('host unreachable')
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        ok = xfer.connect()
+    assert ok is False
+    assert xfer.connected is False
+
+
+def test_connect_sets_channel_timeout_when_configured():
+    xfer = _make_sftp()
+    xfer.o.timeout = 42
+
+    fake_client, fake_sftp = _make_fake_client()
+    fake_channel = fake_sftp.get_channel.return_value
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        xfer.connect()
+
+    fake_channel.settimeout.assert_called_with(42)
+
+
+# ----- get / put: file() round-trip via read_write loop -----
+
+
+class _FakeSFTPFile(io.BytesIO):
+    """BytesIO that also implements the paramiko.SFTPFile-shaped methods
+    sarracenia calls on the object returned by sftp.file(): settimeout,
+    seek (inherited), close (snapshots bytes first), truncate (inherited)."""
+
+    captured = b''
+
+    def settimeout(self, _t):
+        return None
+
+    def close(self):
+        if not self.closed:
+            self.captured = self.getvalue()
+        super().close()
+
+
+def test_get_round_trips_bytes(tmp_path):
+    """Sftp.get() drives read_writelocal -> read_write; mock sftp.file() with BytesIO."""
+    xfer = _make_sftp()
+    payload = b'A' * 65536 + b'tail'
+
+    fake_client, fake_sftp = _make_fake_client()
+    fake_sftp.file.return_value = _FakeSFTPFile(payload)
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        assert xfer.connect()
+
+    local = tmp_path / 'out.bin'
+    rw = xfer.get(msg={}, remote_file='remote.bin', local_file=str(local))
+
+    assert rw == len(payload)
+    assert local.read_bytes() == payload
+
+
+def test_put_round_trips_bytes(tmp_path):
+    """Sftp.put() drives readlocal_write; mock sftp.file() to capture writes."""
+    xfer = _make_sftp()
+    src = tmp_path / 'in.bin'
+    payload = b'PUT' * 20000
+    src.write_bytes(payload)
+
+    fake_client, fake_sftp = _make_fake_client()
+    captured = _FakeSFTPFile()
+    fake_sftp.file.return_value = captured
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        assert xfer.connect()
+
+    rw = xfer.put(msg={}, local_file=str(src), remote_file='remote.bin')
+
+    assert rw == len(payload)
+    assert captured.captured == payload
+
+
+def test_put_with_offset_uses_r_plus_b_and_seeks(tmp_path):
+    """Parts branch: length != 0 + remote_offset triggers 'r+b' open and seek."""
+    xfer = _make_sftp()
+    src = tmp_path / 'in.bin'
+    src.write_bytes(b'PARTS')
+
+    fake_client, fake_sftp = _make_fake_client()
+    fake_sftp.stat.return_value = MagicMock()  # file exists
+    captured = MagicMock()
+    captured.write = MagicMock()
+    captured.seek = MagicMock()
+    captured.settimeout = MagicMock()
+    captured.truncate = MagicMock()
+    fake_sftp.file.return_value = captured
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        assert xfer.connect()
+
+    xfer.put(msg={}, local_file=str(src), remote_file='remote.bin',
+             remote_offset=100, length=5)
+
+    # last open mode should be 'r+b' (parts branch)
+    modes_used = [c.args[1] for c in fake_sftp.file.call_args_list]
+    assert 'r+b' in modes_used
+    captured.seek.assert_called_with(100, 0)
+
+
+# ----- ls / line_callback: SFTPAttributes.__str__ format dependency -----
+
+
+def test_ls_returns_filename_keyed_dict_of_attrs():
+    xfer = _make_sftp()
+    attrs = [
+        _fake_attr('alpha.txt', size=10),
+        _fake_attr('beta.bin', size=2048),
+        _fake_attr('gamma file.dat', size=99),  # filename with whitespace
+    ]
+
+    fake_client, fake_sftp = _make_fake_client()
+    fake_sftp.listdir_attr.return_value = attrs
+    with patch.object(xfer, 'credentials', return_value=True), \
+         patch('sarracenia.transfer.sftp.paramiko.SSHClient', return_value=fake_client):
+        assert xfer.connect()
+
+    entries = xfer.ls()
+
+    assert 'alpha.txt' in entries
+    assert 'beta.bin' in entries
+    assert 'gamma file.dat' in entries
+    assert entries['beta.bin'] is attrs[1]
+
+
+def test_line_callback_parses_attr_str_token_layout():
+    """attr.__str__() must produce >= 9 whitespace-separated tokens
+    so that ' '.join(opart2[8:]) extracts the filename.
+
+    This is the format dependency the upgrade plan must protect: if paramiko
+    ever changes SFTPAttributes.__str__ layout, this test fails first."""
+    xfer = _make_sftp()
+    attr = _fake_attr('hello.world', size=42)
+    rendered = attr.__str__()
+    tokens = [p for p in rendered.strip().replace('\t', ' ').split(' ') if p]
+    assert len(tokens) >= 9, (
+        f"paramiko {paramiko.__version__} SFTPAttributes.__str__ produced "
+        f"fewer than 9 tokens; line_callback's opart2[8:] filename split will "
+        f"misbehave. Raw: {rendered!r}"
+    )
+
+    xfer.entries = {}
+    xfer.line_callback(rendered, attr)
+    # Whatever line_callback decides the filename is, the attr must be retrievable.
+    assert attr in xfer.entries.values()
+
+
+# ----- identity check used by flowcb/poll -----
+
+
+def test_paramiko_sftpattributes_identity_check():
+    """flowcb/poll/__init__.py:358 uses `type(line) is paramiko.SFTPAttributes`.
+    Confirm that hand-constructed instances satisfy that identity test, and
+    that the class is not shadowed/wrapped by anything in the import chain."""
+    import sarracenia.flowcb.poll as poll_mod
+    a = paramiko.SFTPAttributes()
+    assert type(a) is paramiko.SFTPAttributes
+    assert type(a) is poll_mod.paramiko.SFTPAttributes
+    assert paramiko.SFTPAttributes is poll_mod.paramiko.SFTPAttributes
+
+
+def test_sftpattributes_writable_fields_unchanged():
+    """The 8 hand-construction call sites assign these fields by name.
+    If paramiko ever renames any of them, this test fails early."""
+    a = paramiko.SFTPAttributes()
+    a.st_size = 1
+    a.st_mtime = 2
+    a.st_atime = 3
+    a.st_mode = 0o644
+    a.st_uid = 0
+    a.st_gid = 0
+    a.filename = 'x'
+    a.longname = 'x'
+    assert a.st_size == 1
+    assert a.st_mtime == 2
+    assert a.st_atime == 3
+    assert a.st_mode == 0o644
+    assert a.filename == 'x'
+    assert a.longname == 'x'
+
+
+# ----- check_is_connected close/reset semantics -----
+
+
+def test_check_is_connected_false_when_sftp_none():
+    xfer = _make_sftp()
+    xfer.sftp = None
+    xfer.connected = True
+    assert xfer.check_is_connected() is False
+
+
+def test_check_is_connected_false_when_not_connected_flag():
+    xfer = _make_sftp()
+    xfer.sftp = MagicMock()
+    xfer.connected = False
+    assert xfer.check_is_connected() is False


### PR DESCRIPTION
## Context

Open issue #3 / PR #4 concluded that upgrading paramiko 2.9.3 → 4.0.0 yields a 15–22 % SFTP transport speedup with zero code change, and issue #8 adds a further 13.8 % at 64 KB packet size. That work measured the win but never landed a pin or a regression net.

This PR is **Stage 0** of a staged paramiko-upgrade plan tracked in **#24**. The plan was rewritten 2026-06-10 after verifying that Ubuntu 26.04 LTS (resolute) ships `paramiko 4.0.0-1ubuntu2` in `main` — meaning the apt-first strategy and the 15-22 % speedup are no longer in tension. Building sarracenia for 26.04 is now the headline deliverable; this PR is the regression net the 26.04 build depends on.

An adversarial review of an earlier draft invalidated three central claims of the first plan:

1. **"272 passing tests across 3 paramiko versions proves the API surface is stable" — false.** Every `tests/sarracenia/flowcb/poll/*_test.py` is a 5-line import stub with zero test functions, `__transfer___test.py` covers only the HTTP factory, and no test imports `sarracenia.transfer.sftp`. The paramiko surface is exercised by exactly zero non-stub tests on `development`.
2. **"Leaving `debian/control` alone keeps apt users unaffected" — false.** `dh-python` derives runtime `Depends:` from `pyproject.toml` via pybuild. A pin in pyproject.toml propagates into the `.deb`.
3. **"Cherry-pick PR #4's `sftp_test.py` and strip the `useCompression` assertions" — unviable.** 7/10 of those tests are structurally inseparable from the feature patch they were written for.

This PR closes the first gap by adding a real mock-paramiko regression net for `sarracenia.transfer.sftp`, written from scratch (no PR #4 dependency, no production code touched). It is the prerequisite for the remaining stages (config-option escape hatch for the RSA-SHA2 landmine, then the pin change + `.deb` build verification on resolute).

## What's in this PR

`tests/sarracenia/transfer/sftp_test.py` — 17 tests covering the paramiko surface that the pin change and the 26.04 `.deb` need to protect:

- **Connect**: kwarg propagation in both auth branches (positional host/port/user/password, key_filename, allow_agent=False, look_for_keys=False), `AutoAddPolicy` confirmation, channel timeout, failure paths (`credentials()` False, ssh.connect raises).
- **Get / Put**: `SFTPClient.file()` round-trips via the `read_writelocal` / `readlocal_write` loop, including the parts branch (`length != 0` + `remote_offset`) that opens `'r+b'` and seeks.
- **Ls / line_callback**: `SFTPClient.listdir_attr()` through the filename-keyed entries dict; filenames with embedded whitespace.
- **The `SFTPAttributes.__str__` token layout canary**: `line_callback`'s `' '.join(opart2[8:])` filename extraction at `sftp.py:444` requires ≥ 9 whitespace-separated tokens. The test reads the live paramiko version and asserts the layout. **This is the largest-blast-radius drift risk for the 26.04 move**, since it's the only test that exercises the difference between paramiko 2.x and 4.x string output and the fleet's apt floor is jumping straight from 2.9.3 (jammy) to 4.0.0 (resolute) in one OS refresh.
- **Identity check**: `flowcb/poll/__init__.py:358` uses `type(line) is paramiko.SFTPAttributes`; the test confirms identity holds across the import chain.
- **Writable fields**: the 8 hand-construction call sites in `poll/*` and `transfer/*` assign `st_size/st_mtime/st_atime/st_mode/st_uid/st_gid/filename/longname` by name. Pin guard.

## Matrix verification

Ran on Python 3.11, fresh venv, against every paramiko major:

| paramiko | cryptography | role | result |
|---|---|---|---|
| 2.9.3 | 41.0.7 | **jammy 22.04 apt baseline** ([USN-6598-1](https://ubuntu.com/security/notices/USN-6598-1) backport carries the Terrapin fix here) | 17 passed (+ expected Blowfish DeprecationWarning) |
| 3.5.1 | 41.0.7 | questing 25.10 (interim, bridge release) | 17 passed |
| **4.0.0** | **46.0.7** | **resolute 26.04 LTS apt baseline** ([Launchpad](https://launchpad.net/ubuntu/+source/paramiko) — primary fleet target, ships `4.0.0-1ubuntu2`) | **17 passed** |
| 5.0.0 | 48.0.1 | PyPI ceiling check (latest) | 17 passed |

Full `tests/sarracenia` suite still passes on paramiko 5.0.0 (modulo the single pre-existing TZ-sensitive `__scheduled___test.py::test_schedules` failure unrelated to paramiko — see CI comment below). No production code changed, so no behavioural risk.

The 4.0.0 leg deserves a callout: it's no longer just "the latest pip-channel default." Resolute (Ubuntu 26.04 LTS) ships paramiko `4.0.0-1ubuntu2` in `main` under USN security patching, which means the same 4.0.0 leg of this matrix simultaneously validates two distinct deployment paths — pip users on PyPI, and fleet hosts running the future 26.04 `.deb`. A green Stage 0 against 4.0.0 is now a precondition for the 26.04 fleet move, not just a pip-channel sanity check.

**Side finding**: paramiko 5.0.0 is on PyPI and clears every test in this file. The originally-planned `paramiko<5` ceiling is too tight; the follow-up pin PR will use `paramiko>=2.9,<6` (also accommodates any future USN-patched `4.0.0-1ubuntu2.x` on resolute without re-pinning).

## Expected CI red (do not block on)

`Test Results` reports `1 failed / 347 passed / 1 skipped` against this PR. The single failure is **`tests/sarracenia/flowcb/scheduled/__scheduled___test.py::test_schedules`** — a pre-existing TZ-sensitive test that hardcodes appointment times as local-clock and fails on UTC GitHub runners. Math: `assert how_long.total_seconds() == 7020` got `14220`; `14220 - 7020 = 7200s = exactly 2 hours` of TZ offset. This PR's diff is one file (`tests/sarracenia/transfer/sftp_test.py`, +373/-0) and touches nothing under `sarracenia/flowcb/scheduled/`, so the failure is not introduced here. See the PR comment for the full investigation. A `freezegun` / TZ-pinning fix is out of scope for the paramiko-upgrade plan and should be filed as its own follow-up.

## Not in this PR (deferred stages — see #24)

- **Stage 1**: add a `disabledKeyAlgorithms` config option to `Sftp` so users can escape the paramiko-2.9.0 RSA-SHA2 landmine on legacy SFTP servers (still relevant for jammy hosts mid-migration to 26.04).
- **Stage 2**: clean container matrix across the three LTS combos — `ubuntu:22.04` (paramiko 2.9.3 + cryptography 3.4.8 + Python 3.10), `ubuntu:24.04` (2.12.0 + 41.x + 3.12), and **`ubuntu:26.04` (4.0.0 + 43.0.0 + 3.14.3)** — plus `sr_insects` flow integration tests with side-by-side jammy/resolute throughput capture.
- **Stage 3**: ship the pin `paramiko>=2.9,<6` across `requirements.txt` / `pyproject.toml` / `setup.py` / `requirements-dev.txt` / `windows/sarracenia_env.yml` / `generate-win-installer.sh`, plus the CI `paths:` and matrix fix, plus removing the dead `import paramiko` in `flowcb/scheduled/__init__.py:2` and the `from paramiko import *` star import at `sftp.py:25`. **No cryptography pin in runtime metadata** — that would brick the `.deb` on jammy (ships 3.4.8) via dh-python. The Stage 3 PR also adds a `dpkg-buildpackage` job on `ubuntu:26.04` that produces the `.deb`, runs `lintian`, then `apt-get install`s it in a fresh resolute container — proving the end-to-end "apt installs paramiko 4.0.0 with no pip" experience that justifies the fleet OS refresh.

Marking as draft until the user reviews and Stages 1–3 are ready to follow.

## Test plan

- [x] `pytest tests/sarracenia/transfer/sftp_test.py` — 17 passed on each of paramiko 2.9.3 / 3.5.1 / 4.0.0 / 5.0.0
- [x] Full `pytest tests/sarracenia` green except the pre-existing TZ-sensitive `__scheduled___test.py::test_schedules` failure (unrelated to paramiko)
- [x] Fork CI matches: 347 passed, 1 skipped, 1 failed (the `test_schedules` failure above)
- [ ] Run inside `ubuntu:26.04` container against the apt-installed `python3-paramiko 4.0.0-1ubuntu2` — proves the resolute distro-true combo, not just a pip-installed 4.0.0 (deferred to Stage 2)
- [ ] sr_insects flow tests (deferred to Stage 2)

https://claude.ai/code/session_0176q2w5sktt7ep5hAdHmnn7

---
_Generated by [Claude Code](https://claude.ai/code/session_0176q2w5sktt7ep5hAdHmnn7)_